### PR TITLE
style(TaskList): prevent the scrolling content between the header and subheader from becoming visible

### DIFF
--- a/src/components/TaskList/TaskList.tsx
+++ b/src/components/TaskList/TaskList.tsx
@@ -8,6 +8,7 @@ import TaskListItem from "../TaskListItem";
 
 const StyledListSubheader = styled(ListSubheader)`
   // avoid scrollbar overlapping (Safari mobile)
+  top: -1px;
   margin-right: ${({ theme }) => theme.spacing(1)};
   background: linear-gradient(
     to top,


### PR DESCRIPTION
prevent the scrolling content between the header and subheader from becoming visible