### PR TITLE
style(TaskForm) hide completion date input field when editing an incomplete task

### DIFF
--- a/src/components/TaskDialog.tsx
+++ b/src/components/TaskDialog.tsx
@@ -130,6 +130,7 @@ const TaskDialog = () => {
       </DialogTitle>
       <DialogContent>
         <TaskForm
+          completed={!!task?.completed}
           formData={formData}
           contexts={Object.keys(contexts)}
           projects={Object.keys(projects)}

--- a/src/components/TaskForm.test.tsx
+++ b/src/components/TaskForm.test.tsx
@@ -42,12 +42,13 @@ const TestComp = (props: TestCompProps) => {
 
   return (
     <TaskForm
+      completed={false}
       projects={projects}
       contexts={contexts}
       tags={tags}
       formData={_formData}
       taskLists={[]}
-      onFileListChange={() => undefined}
+      onFileSelect={() => undefined}
       onChange={handleChange}
       onEnterPress={handleEnterPress}
     />

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -18,18 +18,19 @@ import LocalizationDatePicker from "./LocalizationDatePicker";
 import PrioritySelect from "./PrioritySelect";
 import TaskEditor from "./TaskEditor/TaskEditor";
 
-interface TaskDialogForm {
+interface TaskFormProps {
   formData: TaskFormData;
   projects: string[];
   contexts: string[];
   tags: Dictionary<string[]>;
   taskLists: TaskListState[];
+  completed: boolean;
   onChange: (value: TaskFormData) => void;
   onFileSelect: (value?: TaskListState) => void;
   onEnterPress: () => void;
 }
 
-const TaskForm = (props: TaskDialogForm) => {
+const TaskForm = (props: TaskFormProps) => {
   const platform = usePlatform();
   const hasTouchScreen = useTouchScreen();
   const {
@@ -38,11 +39,19 @@ const TaskForm = (props: TaskDialogForm) => {
     tags,
     contexts,
     taskLists,
+    completed,
     onChange,
     onFileSelect,
     onEnterPress,
   } = props;
   const { t } = useTranslation();
+  const showCreationDate = !!formData._id;
+  const showCompletionDate = !!formData._id && completed;
+  const mdGridItems =
+    (showCreationDate || showCompletionDate) &&
+    !(showCreationDate && showCompletionDate)
+      ? 4
+      : 6;
   const [state, setState] = useState({
     key: 0,
     projects,
@@ -173,14 +182,14 @@ const TaskForm = (props: TaskDialogForm) => {
             <FileSelect options={taskLists} onSelect={onFileSelect} />
           </Grid>
         )}
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} md={mdGridItems}>
           <PrioritySelect
             value={formData.priority}
             onChange={(priority) => onChange({ ...formData, priority })}
           />
         </Grid>
-        {formData._id && (
-          <Grid item xs={12} sm={6}>
+        {showCreationDate && (
+          <Grid item xs={12} sm={6} md={mdGridItems}>
             <LocalizationDatePicker
               ariaLabel="Creation date"
               label={t("Creation Date")}
@@ -193,8 +202,8 @@ const TaskForm = (props: TaskDialogForm) => {
             />
           </Grid>
         )}
-        {formData._id && (
-          <Grid item xs={12} sm={6}>
+        {showCompletionDate && (
+          <Grid item xs={12} sm={6} md={mdGridItems}>
             <LocalizationDatePicker
               ariaLabel="Completion date"
               label={t("Completion Date")}
@@ -207,7 +216,7 @@ const TaskForm = (props: TaskDialogForm) => {
             />
           </Grid>
         )}
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} md={mdGridItems}>
           <LocalizationDatePicker
             ariaLabel="Due date"
             label={t("Due Date")}


### PR DESCRIPTION
When editing an incomplete task, the input field for the completion date should be hidden because it is not needed in this state.